### PR TITLE
Add a docker compose file to setup MySQL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+# 关于Compose文件的具体说明，请参考以下链接：
+# https://docs.docker.com/compose/compose-file/
+
+version: "3.5"
+services:
+  # 数据库的各种配置参数，请参考以下链接：
+  # https://github.com/piexlmax/gin-vue-admin/blob/master/QMPlusServer/db/qmplus.sql#L4-L8
+  # https://github.com/piexlmax/gin-vue-admin/blob/master/QMPlusServer/static/config/config.json#L8-L14
+  database:
+    image: mysql:5.6
+    ports:
+      - 3306:3306
+    volumes:
+      - ./QMPlusServer/db:/docker-entrypoint-initdb.d
+    environment:
+      MYSQL_ROOT_PASSWORD: Aa@6447985
+      MYSQL_DATABASE: qmPlus
+    user: root


### PR DESCRIPTION
### 目的

如果你安装了Docker，便可以迅速部署本项目所需要的MySQL数据库。
https://github.com/piexlmax/gin-vue-admin/issues/16 中提到的方法启发了我，但是，我没能部署所有的服务。
希望以后有机会可以完善这个Compose文件。

### 前提

Docker的版本不能低于 `17.12.0+` 。Docker的版本与Compose文件的 `version` 相关，请参考以下链接：
https://docs.docker.com/compose/compose-file/#compose-and-docker-compatibility-matrix

### 用法

在 `docker-compose.yml` 所在的目录下

- 启动MySQL：`docker-compose up -d`
- 关闭MySQL：`docker-compose down`
- 删除数据卷：`docker volume prune -f`