### PR TITLE
Containerize QMPlusServer

### DIFF
--- a/QMPlusServer/Dockerfile
+++ b/QMPlusServer/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.12 AS build
+
+WORKDIR /go/src/gin-vue-admin
+COPY . .
+
+ENV GO111MODULE=on
+ENV GOPROXY=https://goproxy.cn
+RUN go get ./... \
+    && go build -o gin-vue-admin
+
+FROM golang:1.12 AS serve
+
+COPY --from=build /go/src/gin-vue-admin /go/src/gin-vue-admin
+
+EXPOSE 8080
+ENTRYPOINT [ "./gin-vue-admin" ]

--- a/QMPlusServer/init/qmsql/initMysql.go
+++ b/QMPlusServer/init/qmsql/initMysql.go
@@ -1,10 +1,12 @@
 package qmsql
 
 import (
-	"gin-vue-admin/config"
+	"log"
+
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/mysql"
-	"log"
+
+	"gin-vue-admin/config"
 )
 
 var DEFAULTDB *gorm.DB
@@ -12,7 +14,8 @@ var DEFAULTDB *gorm.DB
 //初始化数据库并产生数据库全局变量
 func InitMysql(admin config.MysqlAdmin) *gorm.DB {
 	if db, err := gorm.Open("mysql", admin.Username+":"+admin.Password+"@("+admin.Path+")/"+admin.Dbname+"?"+admin.Config); err != nil {
-		log.Printf("DEFAULTDB数据库启动异常%S", err)
+		// 数据库初始化失败时，直接退出程序
+		log.Fatalf("DEFAULTDB数据库启动异常: %s", err)
 	} else {
 		DEFAULTDB = db
 		DEFAULTDB.DB().SetMaxIdleConns(10)

--- a/QMPlusServer/main.go
+++ b/QMPlusServer/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"gin-vue-admin/cmd"
 	"gin-vue-admin/config"
 	"gin-vue-admin/init/initRedis"
@@ -19,9 +21,26 @@ import (
 // @name x-token
 // @BasePath /
 
+var (
+	mysqlHost = os.Getenv("MYSQLHOST")
+	mysqlPort = os.Getenv("MYSQLPORT")
+)
+
 func main() {
-	qmlog.InitLog()                                            // 初始化日志
-	db := qmsql.InitMysql(config.GinVueAdminconfig.MysqlAdmin) // 链接初始化数据库
+	qmlog.InitLog() // 初始化日志
+
+	// 可以通过环境变量来覆盖默认值
+	// 未设定有效的环境变量时，使用默认值
+	mysqlConfig := config.GinVueAdminconfig.MysqlAdmin
+	if mysqlHost == "" {
+		mysqlHost = "localhost"
+	}
+	if mysqlPort == "" {
+		mysqlPort = "3306"
+	}
+	mysqlConfig.Path = mysqlHost + ":" + mysqlPort
+
+	db := qmsql.InitMysql(mysqlConfig) // 链接初始化数据库
 	if config.GinVueAdminconfig.System.UseMultipoint {
 		_ = initRedis.InitRedis() // 初始化redis服务
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,3 +16,14 @@ services:
       MYSQL_ROOT_PASSWORD: Aa@6447985
       MYSQL_DATABASE: qmPlus
     user: root
+  server:
+    build: ./QMPlusServer
+    ports:
+      - 8080:8080
+      - 8888:8888
+    environment:
+      MYSQLHOST: database
+    working_dir: /go/src/gin-vue-admin
+    restart: always
+    depends_on:
+      - database


### PR DESCRIPTION
### 目的

容器化后端服务。在编排容器时已经进行了端口映射。在宿主机中可以正常查看swagger构建的文档。

### 用法

- 在首次使用，或者更新过 `QMPlusServer` 目录下的 `Dockerfile` 之后，必须运行： `docker-compose build`
- 日常使用时只需要： `docker-compose up -d`
