### PR TITLE
Add retry process for database connection

### DIFF
--- a/QMPlusServer/config/config.go
+++ b/QMPlusServer/config/config.go
@@ -2,6 +2,10 @@ package config
 
 import (
 	"fmt"
+	"log"
+	"strconv"
+	"time"
+
 	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/viper"
 )
@@ -36,6 +40,12 @@ type MysqlAdmin struct { // mysql admin 数据库配置
 	Path     string `json:"path"`
 	Dbname   string `json:"dbname"`
 	Config   string `json:"config"`
+	Retry    Retry
+}
+
+type Retry struct {
+	Count int
+	Wait  time.Duration
 }
 
 type RedisAdmin struct { // Redis admin 数据库配置
@@ -77,4 +87,32 @@ func init() {
 		fmt.Println(err)
 	}
 	VTool = v
+}
+
+// SetPath ...
+func (config *MysqlAdmin) SetPath(host, port string) {
+
+	if host == "" {
+		host = "localhost"
+	}
+	if port == "" {
+		port = "3306"
+	}
+	config.Path = host + ":" + port
+}
+
+// SetRetry ...
+func (config *MysqlAdmin) SetRetry(count, delay string) {
+
+	cnt, err := strconv.Atoi(count)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	config.Retry.Count = cnt
+
+	wait, err := strconv.Atoi(delay)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	config.Retry.Wait = time.Duration(wait) * time.Second
 }

--- a/QMPlusServer/go.mod
+++ b/QMPlusServer/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc
 	github.com/casbin/casbin v1.9.1
 	github.com/casbin/gorm-adapter v1.0.0
+	github.com/cenkalti/backoff/v4 v4.0.0
 	github.com/dchest/captcha v0.0.0-20170622155422-6a29415a8364
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/fastly/go-utils v0.0.0-20180712184237-d95a45783239 // indirect

--- a/QMPlusServer/init/qmsql/initMysql.go
+++ b/QMPlusServer/init/qmsql/initMysql.go
@@ -3,6 +3,7 @@ package qmsql
 import (
 	"log"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/mysql"
 
@@ -13,13 +14,25 @@ var DEFAULTDB *gorm.DB
 
 //初始化数据库并产生数据库全局变量
 func InitMysql(admin config.MysqlAdmin) *gorm.DB {
-	if db, err := gorm.Open("mysql", admin.Username+":"+admin.Password+"@("+admin.Path+")/"+admin.Dbname+"?"+admin.Config); err != nil {
-		// 数据库初始化失败时，直接退出程序
-		log.Fatalf("DEFAULTDB数据库启动异常: %s", err)
-	} else {
-		DEFAULTDB = db
-		DEFAULTDB.DB().SetMaxIdleConns(10)
-		DEFAULTDB.DB().SetMaxOpenConns(100)
+
+	// 当DB无法连接时，进行适当的Retry处理
+	var err error
+	openDB := func() error {
+		DEFAULTDB, err = gorm.Open("mysql", admin.Username+":"+admin.Password+"@("+admin.Path+")/"+admin.Dbname+"?"+admin.Config)
+		if err != nil {
+			return err
+		}
+		return nil
 	}
+	policy := backoff.WithMaxRetries(backoff.NewConstantBackOff(admin.Retry.Wait), uint64(admin.Retry.Count))
+
+	err = backoff.Retry(openDB, policy)
+	if err != nil {
+		// Retry之后仍然无法连接，数据库初始化失败，直接退出程序
+		log.Fatalf("DEFAULTDB数据库启动异常: %s", err)
+	}
+
+	DEFAULTDB.DB().SetMaxIdleConns(10)
+	DEFAULTDB.DB().SetMaxOpenConns(100)
 	return DEFAULTDB
 }

--- a/QMPlusServer/main.go
+++ b/QMPlusServer/main.go
@@ -22,8 +22,10 @@ import (
 // @BasePath /
 
 var (
-	mysqlHost = os.Getenv("MYSQLHOST")
-	mysqlPort = os.Getenv("MYSQLPORT")
+	mysqlHost       = os.Getenv("MYSQL_HOST")
+	mysqlPort       = os.Getenv("MYSQL_PORT")
+	mysqlRetryCount = os.Getenv("MYSQL_RETRY_COUNT")
+	mysqlRetryWait  = os.Getenv("MYSQL_RETRY_WAIT")
 )
 
 func main() {
@@ -32,13 +34,8 @@ func main() {
 	// 可以通过环境变量来覆盖默认值
 	// 未设定有效的环境变量时，使用默认值
 	mysqlConfig := config.GinVueAdminconfig.MysqlAdmin
-	if mysqlHost == "" {
-		mysqlHost = "localhost"
-	}
-	if mysqlPort == "" {
-		mysqlPort = "3306"
-	}
-	mysqlConfig.Path = mysqlHost + ":" + mysqlPort
+	mysqlConfig.SetPath(mysqlHost, mysqlPort)
+	mysqlConfig.SetRetry(mysqlRetryCount, mysqlRetryWait)
 
 	db := qmsql.InitMysql(mysqlConfig) // 链接初始化数据库
 	if config.GinVueAdminconfig.System.UseMultipoint {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@
 # https://docs.docker.com/compose/compose-file/
 
 version: "3.5"
+
 services:
   # 数据库的各种配置参数，请参考以下链接：
   # https://github.com/piexlmax/gin-vue-admin/blob/master/QMPlusServer/db/qmplus.sql#L4-L8
@@ -15,14 +16,16 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: Aa@6447985
       MYSQL_DATABASE: qmPlus
-    user: root
+
   server:
     build: ./QMPlusServer
     ports:
-      - 8080:8080
       - 8888:8888
     environment:
-      MYSQLHOST: database
+      MYSQL_HOST: database
+      MYSQL_PORT: 3306
+      MYSQL_RETRY_COUNT: 3
+      MYSQL_RETRY_WAIT: 10 # second
     working_dir: /go/src/gin-vue-admin
     restart: always
     depends_on:


### PR DESCRIPTION
网络抖动以及数据库重启等很多原因，都会造成数据库暂时性无法连接。
后端服务器应该尽量容忍这些问题，并且进行适当的重试。
重试的次数和重试的间隔可以通过环境变量进行定制。