### PR TITLE
Refine Dockerfile of QMPlusServer

### DIFF
--- a/QMPlusServer/Dockerfile
+++ b/QMPlusServer/Dockerfile
@@ -1,16 +1,11 @@
-FROM golang:1.12 AS build
+FROM golang:1.12-alpine
 
 WORKDIR /go/src/gin-vue-admin
 COPY . .
 
-ENV GO111MODULE=on
-ENV GOPROXY=https://goproxy.cn
-RUN go get ./... \
-    && go build -o gin-vue-admin
+ENV GO111MODULE=on \
+    GOPROXY=https://goproxy.cn
+RUN go mod download
 
-FROM golang:1.12 AS serve
-
-COPY --from=build /go/src/gin-vue-admin /go/src/gin-vue-admin
-
-EXPOSE 8080
+RUN go build -ldflags="-s -w" -o gin-vue-admin
 ENTRYPOINT [ "./gin-vue-admin" ]


### PR DESCRIPTION
1. 通过使用 `alpine` 镜像，以及改变 `go build` 编译时的设置，减小镜像的体积
2. 通过 `go mod download` 来缓存外部依赖，尽量提高镜像的编译速度